### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.9.1

### DIFF
--- a/ep-common/pom.xml
+++ b/ep-common/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>[2.9.9.1,)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Proposed changes
A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.x through 2.9.9. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has JDOM 1.x or 2.x jar in the classpath, an attacker can send a specifically crafted JSON message that allows them to read arbitrary local files on the server.

## Types of changes
- [ ] Bugfix
- [ ] New feature or enhancement
- [V] Others

## Checklist
- [V] I have read the [CONTRIBUTING](https://github.com/klaytn/enterprise_proxy/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/klaytn/enterprise_proxy)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments